### PR TITLE
add first tests for inventories

### DIFF
--- a/src/pyclts/inventories.py
+++ b/src/pyclts/inventories.py
@@ -8,7 +8,7 @@ import statistics
 
 
 def reduce_features(sound, clts=None, features=None):
-    clts = CLTS().bipa or clts
+    clts = clts or CLTS().bipa
     features = features or {
             'consonant': ['phonation', 'place', 'manner'],
             'vowel': ['roundedness', 'height', 'centrality'],

--- a/src/pyclts/inventories.py
+++ b/src/pyclts/inventories.py
@@ -1,0 +1,81 @@
+"""
+Module handles different aspects of inventory comparison.
+"""
+import attr
+from collections import defaultdict
+from pyclts.api import CLTS
+import statistics
+
+
+def reduce_features(sound, clts=None, features=None):
+    clts = CLTS().bipa or clts
+    features = features or {
+            'consonant': ['phonation', 'place', 'manner'],
+            'vowel': ['roundedness', 'height', 'centrality'],
+            'tone': ['start']
+            }
+    sound_ = clts[sound] if isinstance(sound, str) else sound
+    if sound_.type in ['cluster', 'diphthong']:
+        return reduce_features(sound_.from_sound, clts=clts, features=features)
+    name = ' '.join([s for s in [sound_.featuredict.get(x) for x in
+        features[sound_.type]] if s])+' '+sound_.type
+    if sound_.type != 'tone':
+        return clts[name]
+    return clts['short '+' '.join(name.split(' '))]
+
+
+@attr.s
+class Inventory:
+    sounds = attr.ib()
+    clts = attr.ib(default=None)
+
+    @classmethod
+    def from_list(cls, *list_of_sounds, clts=None):
+        clts = clts or CLTS().bipa
+
+        sounds = defaultdict(dict)
+        for itm in list_of_sounds:
+            sound = clts[itm]
+            sounds[sound.type][sound.s] = sound
+            for ft, val in sound.featuredict.items():
+                if val:
+                    sounds[val][sound.s] = sound
+        return cls(sounds=sounds, clts=clts)
+    
+    def similar(self, other, metric='strict', aspects=None):
+        aspects = aspects or ['consonant', 'vowel', 'tone']
+
+        def jac(a, b):
+            return len(set(a).intersection(set(b))) / len(set(a).union(set(b)))
+        
+        if metric == 'strict':
+            score = []
+            for aspect in aspects:
+                if aspect in self.sounds or aspect in other.sounds:
+                    score += [jac(self.sounds[aspect], other.sounds[aspect])]
+            return statistics.mean(score)
+
+        if metric == 'approximate':
+            score = []
+            for aspect in aspects:
+                soundsA = list(self.sounds[aspect].values())
+                soundsB = list(other.sounds[aspect].values())
+                matches = []
+                for sA in soundsA:
+                    best, sim = None, 0
+                    for sB in soundsB:
+                        if sA.similarity(sB) > sim:
+                            sim = sA.similarity(sB)
+                            best = sB
+                    if best:
+                        soundsB = [s for s in soundsB if s != best]
+                        matches += [sim]
+                    else:
+                        matches += [0]
+                matches += [0 for s in soundsB]
+                if matches:
+                    score += [sum(matches) / len(matches)]
+            return statistics.mean(score)
+
+            
+

--- a/tests/test_inventories.py
+++ b/tests/test_inventories.py
@@ -1,0 +1,16 @@
+import pytest
+from pyclts.inventories import reduce_features, Inventory
+
+def test_reduce_features():
+    assert reduce_features('th').s == 't'
+    assert reduce_features('oe').s == 'o'
+    assert reduce_features('⁵⁵').s == '⁵'
+
+
+def test_Inventory():
+    inv1 = Inventory.from_list('a', 'e', 'i', 'o', 'p')
+    inv2 = Inventory.from_list('a', 'e', 'i', 'œ', 'p')
+    inv3 = Inventory.from_list('a', 'e', 'i', 'æ', 'p')
+    assert inv1.similar(inv2, metric='strict') == inv1.similar(inv3, metric='strict')
+    assert inv1.similar(inv2, metric='approximate') > inv1.similar(
+            inv3, metric='approximate')

--- a/tests/test_inventories.py
+++ b/tests/test_inventories.py
@@ -1,16 +1,35 @@
 import pytest
 from pyclts.inventories import reduce_features, Inventory
+from pathlib import Path
+from pyclts.transcriptionsystem import TranscriptionSystem
 
 def test_reduce_features():
-    assert reduce_features('th').s == 't'
-    assert reduce_features('oe').s == 'o'
-    assert reduce_features('⁵⁵').s == '⁵'
+    bipa = TranscriptionSystem(
+            Path(__file__).parent.joinpath('repos', 'pkg',
+                'transcriptionsystems', 'bipa'),
+            Path(__file__).parent.joinpath('repos', 'pkg',
+                'transcriptionsystems', 'transcription-system-metadata.json'),
+            Path(__file__).parent.joinpath('repos', 'pkg',
+                'transcriptionsystems', 'features.json'),
+            )
+    assert reduce_features('th', clts=bipa).s == 't'
+    assert reduce_features('oe', clts=bipa).s == 'o'
+    assert reduce_features('⁵⁵', clts=bipa).s == '⁵'
 
 
 def test_Inventory():
-    inv1 = Inventory.from_list('a', 'e', 'i', 'o', 'p')
-    inv2 = Inventory.from_list('a', 'e', 'i', 'œ', 'p')
-    inv3 = Inventory.from_list('a', 'e', 'i', 'æ', 'p')
+    bipa = TranscriptionSystem(
+            Path(__file__).parent.joinpath('repos', 'pkg',
+                'transcriptionsystems', 'bipa'),
+            Path(__file__).parent.joinpath('repos', 'pkg',
+                'transcriptionsystems', 'transcription-system-metadata.json'),
+            Path(__file__).parent.joinpath('repos', 'pkg',
+                'transcriptionsystems', 'features.json'),
+            )
+
+    inv1 = Inventory.from_list('a', 'e', 'i', 'o', 'p', clts=bipa)
+    inv2 = Inventory.from_list('a', 'e', 'i', 'œ', 'p', clts=bipa)
+    inv3 = Inventory.from_list('a', 'e', 'i', 'æ', 'p', clts=bipa)
     assert inv1.similar(inv2, metric='strict') == inv1.similar(inv3, metric='strict')
     assert inv1.similar(inv2, metric='approximate') > inv1.similar(
             inv3, metric='approximate')


### PR DESCRIPTION
This proposes a first very simple metric for comparing inventories. The idea is that we use the `sound.similar(othersound)` method based on jaccard-distance in pyclts to find the best matches between two inventories. Once this has been done, this yields a revised jaccard distance. 

Furthermore, the "aspects" keyword allows to specify what one wants to compare. Since sounds are ordered by major feature values, one can compare also only the stops or only the nasals, or only the consonants.
