### PR TITLE
Add new method for computing similarity

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     extras_require={
         'dev': ['flake8', 'wheel', 'twine'],
         'test': [
-            'pytest>=3.6',
+            'pytest>=5.4',
             'pytest-mock',
             'mock',
             'pytest-cov',

--- a/tests/test_inventories.py
+++ b/tests/test_inventories.py
@@ -33,3 +33,5 @@ def test_Inventory():
     assert inv1.similar(inv2, metric='strict') == inv1.similar(inv3, metric='strict')
     assert inv1.similar(inv2, metric='approximate') > inv1.similar(
             inv3, metric='approximate')
+    assert inv1.similar(inv2, metric="similarity") == inv2.similar(inv3, metric="similarity")
+    assert inv1.similar(inv2, metric="similarity") > inv1.similar(inv3, metric="similarity")


### PR DESCRIPTION
This PR adds a new method for comparing inventories, along with two tests, that is more suitable for comparing inventories derived from Lexibank datasets.

The other approximate method compares the sounds in both inventories in the order returned by `.values()`, which means that the pair of sounds removed at each iteration is not necessarily the best one in terms of asymmetric information.

E.g., if you have (in this order), `["a:", "a"]` in inventory #1 and only `["a"]` in inventory #2, the first element `"a:"` will be matched with the `"a"` in the second inventory (giving a lower overall score). When it will be the turn for the `"a"` in the first inventory to be consider, the perfect match on the other site will have been removed, potentially propagating the error (`"a"` could match an `"æ"`, which in turn could match an `"e"`, and so on). 

An additional problem is that under Python 3.5 (where the order of the list returned by `.values()` is not constant) you can get slightly different results at each run. 

This new method is computationally more expansive, building a matrix of similarity for all pairs first, and then removing elements from a sound pair in order of highest overall score (which means matching identical sounds first). It is not necessary to sort lists.