### PR TITLE
Inventory bugfix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 cache: pip
 before_cache: rm -f $HOME/.cache/pip/log/debug.log
 install:
-    - pip install --upgrade pip
+    - pip install --upgrade pip setuptools
     - pip install .[test] codecov
 script: pytest
 after_success: codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 cache: pip
 before_cache: rm -f $HOME/.cache/pip/log/debug.log
 install:
+    - pip install --upgrade pip
     - pip install .[test] codecov
 script: pytest
 after_success: codecov

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ max-line-length = 100
 exclude = .tox
 
 [tool:pytest]
-minversion = 3.6
+minversion = 3.5
 testpaths = tests
 mock_use_standalone_module = true
 addopts = --cov
@@ -25,4 +25,3 @@ source =
 
 [coverage:report]
 show_missing = true
-

--- a/setup.py
+++ b/setup.py
@@ -33,11 +33,11 @@ setup(
     extras_require={
         'dev': ['flake8', 'wheel', 'twine'],
         'test': [
-            'pytest',
+            'pytest==6.0.2',
             'pytest-mock==3.3.1',
             'mock==3.0.5',
             'pytest-cov==2.10.1',
-            'coverage>=4.2',
+            'coverage==5.3',
         ],
     },
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ setup(
         'dev': ['flake8', 'wheel', 'twine'],
         'test': [
             'pytest',
-            'pytest-mock=3.3.1',
+            'pytest-mock==3.3.1',
             'mock==3.0.5',
-            'pytest-cov=2.10.1',
+            'pytest-cov==2.10.1',
             'coverage>=4.2',
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,9 @@ setup(
         'dev': ['flake8', 'wheel', 'twine'],
         'test': [
             'pytest',
-            'pytest-mock',
+            'pytest-mock=3.3.1',
             'mock==3.0.5',
-            'pytest-cov',
+            'pytest-cov=2.10.1',
             'coverage>=4.2',
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,9 @@ setup(
     extras_require={
         'dev': ['flake8', 'wheel', 'twine'],
         'test': [
-            'pytest>=5.4',
+            'pytest',
             'pytest-mock',
-            'mock',
+            'mock==3.0.5',
             'pytest-cov',
             'coverage>=4.2',
         ],

--- a/src/pyclts/inventories.py
+++ b/src/pyclts/inventories.py
@@ -59,8 +59,8 @@ class Inventory:
         if metric == 'approximate':
             score = []
             for aspect in aspects:
-                soundsA = list(self.sounds[aspect].values())
-                soundsB = list(other.sounds[aspect].values())
+                soundsA = sorted(self.sounds[aspect].values())
+                soundsB = sorted(other.sounds[aspect].values())
                 matches = []
                 for sA in soundsA:
                     best, sim = None, 0

--- a/src/pyclts/inventories.py
+++ b/src/pyclts/inventories.py
@@ -59,8 +59,8 @@ class Inventory:
         if metric == 'approximate':
             score = []
             for aspect in aspects:
-                soundsA = sorted(self.sounds[aspect].values())
-                soundsB = sorted(other.sounds[aspect].values())
+                soundsA = list(self.sounds[aspect].values())
+                soundsB = list(other.sounds[aspect].values())
                 matches = []
                 for sA in soundsA:
                     best, sim = None, 0

--- a/tests/test_inventories.py
+++ b/tests/test_inventories.py
@@ -31,7 +31,8 @@ def test_Inventory():
     inv2 = Inventory.from_list('a', 'e', 'i', 'œ', 'p', clts=bipa)
     inv3 = Inventory.from_list('a', 'e', 'i', 'æ', 'p', clts=bipa)
     assert inv1.similar(inv2, metric='strict') == inv1.similar(inv3, metric='strict')
-    assert inv1.similar(inv2, metric='approximate') > inv1.similar(
-            inv3, metric='approximate')
+    print(inv1.similar(inv2, metric='approximate'))
+    print(inv1.similar(inv3, metric='approximate'))
+    assert inv1.similar(inv2, metric='approximate') > inv1.similar(inv3, metric='approximate')
     assert inv1.similar(inv2, metric="similarity") == inv2.similar(inv3, metric="similarity")
     assert inv1.similar(inv2, metric="similarity") > inv1.similar(inv3, metric="similarity")


### PR DESCRIPTION
This PR fixes inventory tests under Python 3.5. Due to backward compatibility issues discussed with @xrotwang , it is pinning the versions of all package dependencies in `extra_require[test]`, namely `pytest`, `pytest-mock`, `mock`, `pytest-cov`, and `coverage`.

When moving from 3.5, we can roll back by simply unpinning those package versions and adjusting the `minversion` variable in `setup.cfg`.